### PR TITLE
fix: deploy workflow permissions for reusable CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       ref: ${{ inputs.commit_sha || '' }}
     permissions:
       contents: read
+      actions: write
+    secrets: inherit
 
   migrate:
     name: Run Supabase Migrations


### PR DESCRIPTION
## Problem
Deploy workflow was failing with `startup_failure` because the `ci-gate` job only granted `contents: read` permission when calling the reusable CI workflow.

However, ci.yml's `e2e-tests` job requires `actions: write` permission for artifact uploads.

## Solution
- Added `actions: write` permission to the `ci-gate` job
- Added `secrets: inherit` to pass secrets to the reusable workflow

## Testing
CI will verify the workflow now passes.